### PR TITLE
Add printTime to M73 command

### DIFF
--- a/octoprint_m73progress/__init__.py
+++ b/octoprint_m73progress/__init__.py
@@ -26,20 +26,19 @@ class M73progressPlugin(octoprint.plugin.ProgressPlugin,
         if storage == "sdcard":
             return
 
-	time = -1
-	try:
-		currentData = self._printer.get_current_data()
-		time = currentData["progress"]["printTime"]
-	except Exception as e:
-		self._logger.info("Caught an exception {0}\nTraceback:{1}".format(e,traceback.format_exc()))
-		
+    try:
+        currentData = self._printer.get_current_data()
+        time = currentData["progress"]["printTime"]
+    except KeyError:
+        self._set_progress(progress)
+    else:
         self._set_progress(progress, time)
 
-    def _set_progress(self, progress, time=-1):
-		if time == -1:
-			self._printer.commands("M73 P{}".format(progress))
-		else:
-			self._printer.commands("M73 P{0} T{1}".format(progress, time))
+    def _set_progress(self, progress, time=None):
+        if time == None:
+            self._printer.commands("M73 P{}".format(progress))
+        else:
+            self._printer.commands("M73 P{0} T{1}".format(progress, time))
 
     def get_update_information(self):
         return dict(

--- a/octoprint_m73progress/__init__.py
+++ b/octoprint_m73progress/__init__.py
@@ -14,7 +14,7 @@ class M73progressPlugin(octoprint.plugin.ProgressPlugin,
                 return
 
         if event == Events.PRINT_STARTED:
-            self._set_progress(0)
+            self._set_progress(0,0)
         elif event == Events.PRINT_DONE:
             self._set_progress(100)
 
@@ -26,10 +26,20 @@ class M73progressPlugin(octoprint.plugin.ProgressPlugin,
         if storage == "sdcard":
             return
 
-        self._set_progress(progress)
+	time = -1
+	try:
+		currentData = self._printer.get_current_data()
+		time = currentData["progress"]["printTime"]
+	except Exception as e:
+		self._logger.info("Caught an exception {0}\nTraceback:{1}".format(e,traceback.format_exc()))
+		
+        self._set_progress(progress, time)
 
-    def _set_progress(self, progress):
-        self._printer.commands("M73 P{}".format(progress))
+    def _set_progress(self, progress, time=-1):
+		if time == -1:
+			self._printer.commands("M73 P{}".format(progress))
+		else:
+			self._printer.commands("M73 P{0} T{1}".format(progress, time))
 
     def get_update_information(self):
         return dict(


### PR DESCRIPTION
Neat plugin!

I have a [pull request](https://github.com/MarlinFirmware/Marlin/pull/9208) in to Marlin to add a `T` flag to M73 which will take a time in seconds and update the timer above the progress bar.  Assuming that gets accepted, I tweaked your plugin to send the `printTime` value along with the print percentage.  I've got it running on my OctoPi and it seems to work well.

Only other thing I could think of doing was adding a config option to send either time elapsed (printTime) or time remaining (printTimeLeft), but I figured for now just replicating the SD behavior and showing time elapsed was OK.

No need to consider merging this idea until the Marlin PR goes in, just wanted to share it with you.