### PR TITLE
Update the LCD_SET_PROGRESS_MANUALLY note according to changes in Marlin v1.1.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ not enabled by default. You can enable it by uncommenting line 576 in
 #define LCD_SET_PROGRESS_MANUALLY
 ```
 
-**Note:** Marlin requires that `SDSUPPORT` be enabled in order for
+**Note:** The older Marlin versions (1.1.7 and 1.1.8) require that `SDSUPPORT` be enabled in order for
 `LCD_SET_PROGRESS_MANUALLY` to work. See
 [MarlinFirmware/Marlin#9178](https://github.com/MarlinFirmware/Marlin/issues/9178).
 


### PR DESCRIPTION
The latest version of Marlin (1.1.9) allows enabling `LCD_SET_PROGRESS_MANUALLY` without `SDSUPPORT` enabled. See: https://github.com/MarlinFirmware/Marlin/releases/tag/1.1.9